### PR TITLE
Updated to be compatible with meteor 1.17.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric (https://fabricmc.net/versions.html)
-minecraft_version=1.17
-yarn_version=1.17+build.11
+minecraft_version=1.17.1
+yarn_version=1.17.1+build.40
 loader_version=0.11.6
 
 # Mod Properties

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   ],
   "depends": {
     "java": ">=16",
-    "minecraft": ">=1.17",
+    "minecraft": ">=1.17.1",
     "meteor-client": ">0.4.3"
   }
 }


### PR DESCRIPTION
Meteor already updated to 1.17.1 so the template addon is no longer compatible, giving a 'Meteor requires Minecraft version 1.17.1' error ...