### PR TITLE
a few tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Meteor
-    modImplementation "meteordevelopment:meteor-client:${project.meteor_version}"
+    modImplementation "meteordevelopment:meteor-client:+"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,10 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric (https://fabricmc.net/versions.html)
 minecraft_version=1.19
-yarn_mappings=1.19+build.1
+yarn_mappings=1.19+build.4
 loader_version=0.14.7
 
 # Mod Properties
 mod_version=0.1
 maven_group=dummy.package
 archives_base_name=addon-template
-
-# Dependency Versions
-
-# Meteor (https://maven.meteordev.org/)
-meteor_version=0.5.0-SNAPSHOT

--- a/src/main/java/dummy/addon/template/TemplateAddon.java
+++ b/src/main/java/dummy/addon/template/TemplateAddon.java
@@ -26,7 +26,7 @@ public class TemplateAddon extends MeteorAddon {
 		LOG.info("Initializing Meteor Addon Template");
 
 		// Required when using @EventHandler
-		MeteorClient.EVENT_BUS.registerLambdaFactory("meteordevelopment.addons.template", (lookupInMethod, klass) -> (MethodHandles.Lookup) lookupInMethod.invoke(null, klass, MethodHandles.lookup()));
+		MeteorClient.EVENT_BUS.registerLambdaFactory(this.getClass().getPackageName(), (lookupInMethod, klass) -> (MethodHandles.Lookup) lookupInMethod.invoke(null, klass, MethodHandles.lookup()));
 
 		// Modules
 		Modules.get().add(new Example());

--- a/src/main/java/dummy/addon/template/TemplateAddon.java
+++ b/src/main/java/dummy/addon/template/TemplateAddon.java
@@ -1,5 +1,6 @@
 package dummy.addon.template;
 
+import com.mojang.logging.LogUtils;
 import dummy.addon.template.commands.ExampleCommand;
 import dummy.addon.template.modules.AnotherExample;
 import dummy.addon.template.modules.Example;
@@ -12,12 +13,11 @@ import meteordevelopment.meteorclient.systems.hud.HudGroup;
 import meteordevelopment.meteorclient.systems.modules.Category;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 
 public class TemplateAddon extends MeteorAddon {
-	public static final Logger LOG = LoggerFactory.getLogger(TemplateAddon.class);
+	public static final Logger LOG = LogUtils.getLogger();
 	public static final Category CATEGORY = new Category("Example");
     public static final HudGroup HUD_GROUP = new HudGroup("Template");
 


### PR DESCRIPTION
-  replaces `LoggerFactory.getLogger(TemplateAddon.class);` with `LogUtils.getLogger();`, which are functionally identical as `getLogger()` looks at the stack trace to find the caller class

-  updates yarn mappings to match meteor client

-  automatically use latest meteor client commit as we dont really give support for older versions, and if the dev is competent enough, modifying the build script to use an older version is trivial

- automatically get package name when using `registerLambdaFactory`. this could also just be removed and put directly into `MeteorAddon` since `this.getClass().getPackageName()` gets the package name of the subclass