### PR TITLE
Add write perms to workflow

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -4,6 +4,8 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Any repo created from this template has an automatically failing GitHub workflow because the `dev_build` workflow does not have permission to write tags to the repo. This PR fixes this. 