### PR TITLE
remove redundant workflow step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,6 @@ jobs:
         with:
             persist-credentials: false
 
-      - name: Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
-
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 


### PR DESCRIPTION
gradle wrapper validation is already covered by `gradle/actions/setup-gradle@v4`