### PR TITLE
replace `contact.repo` field in `fabric.mod.json` with `contact.sources`

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,7 @@
     "seasnail"
   ],
   "contact": {
-    "repo": "https://github.com/MeteorDevelopment/meteor-addon-template"
+    "sources": "https://github.com/MeteorDevelopment/meteor-addon-template"
   },
   "icon": "assets/template/icon.png",
   "environment": "client",


### PR DESCRIPTION
the [fabric.mod.json specification](https://wiki.fabricmc.net/documentation:fabric_mod_json_spec#contactinformation) defines `sources` as the key that should be used for the project source code repository link